### PR TITLE
Fix client crash: inverted Zone in limitRotateCenter while riding moving contraptions

### DIFF
--- a/common/src/main/java/com/github/leawind/thirdperson/core/CameraAgent.java
+++ b/common/src/main/java/com/github/leawind/thirdperson/core/CameraAgent.java
@@ -171,7 +171,7 @@ public class CameraAgent {
                     ClipContext.Fluid.NONE,
                     entity));
     if (hitResult.getType() == HitResult.Type.BLOCK) {
-      limit = limit.withMax(hitResult.getLocation().y);
+      limit = limit.withMax(Math.max(hitResult.getLocation().y, limit.min));
     }
 
     pickEnd = new Vec3(eyePosition.x, limit.min, eyePosition.z);
@@ -186,7 +186,7 @@ public class CameraAgent {
                     ClipContext.Fluid.NONE,
                     entity));
     if (hitResult.getType() == HitResult.Type.BLOCK) {
-      limit = limit.withMin(hitResult.getLocation().y);
+      limit = limit.withMin(Math.min(hitResult.getLocation().y, limit.max));
     }
 
     for (int i = 0; i < 4; i++) {
@@ -205,7 +205,7 @@ public class CameraAgent {
                       ClipContext.Fluid.NONE,
                       entity));
       if (hitResult.getType() == HitResult.Type.BLOCK) {
-        limit = limit.withMax(hitResult.getLocation().y);
+        limit = limit.withMax(Math.max(hitResult.getLocation().y, limit.min));
       }
 
       pickEnd = new Vec3(eyePosition.x + offsetX, limit.min, eyePosition.z + offsetZ);
@@ -220,7 +220,7 @@ public class CameraAgent {
                       ClipContext.Fluid.NONE,
                       entity));
       if (hitResult.getType() == HitResult.Type.BLOCK) {
-        limit = limit.withMin(hitResult.getLocation().y);
+        limit = limit.withMin(Math.min(hitResult.getLocation().y, limit.max));
       }
     }
 


### PR DESCRIPTION
## Problem

`limitRotateCenter` crashes the client with:

```
java.lang.IllegalArgumentException: Minimum cannot be greater than maximum: 116.0 > 95.93
    at ...utils.math.Zone.<init>
    at ...core.CameraAgent.limitRotateCenter
    at ...core.CameraAgent.onClientTickStart
```

Reported in #221 (flying a Eureka airship, 1.20.1) and #173 (mining underground, float-epsilon case). I hit it reproducibly on **2.3.0 / NeoForge 1.21.1** while piloting a Create Aeronautics plane in third person.

## Root cause

The initial zone is built safely with `Zone.ofAuto`, but the four block-clip results are applied unguarded via `withMax`/`withMin`. The ray origin mixes the *smoothed* x/z with the *current* eye y — on a fast-moving contraption the smoothed origin lags behind the entity and can start inside contraption geometry, so `clip()` returns hit points outside the current `[min, max]`. `withMin(116.0)` on a zone whose max is `95.93` then throws. #173 is the epsilon variant of the same pattern (`130.6048892326653 > 130.60488923265075`).

## Fix

Clamp each hit y into the current zone before applying it, so the limit can only shrink and can never invert — same spirit as the existing `squeezeSafely` call at the end of the method:

```java
limit = limit.withMax(Math.max(hitResult.getLocation().y, limit.min));
...
limit = limit.withMin(Math.min(hitResult.getLocation().y, limit.max));
```

## Testing

I rebuilt the 2.3.0 NeoForge jar with an equivalent guard and it resolved the crash in a 292-mod NeoForge 1.21.1 pack (Create 6 + Create Aeronautics); previously it crashed within ~15 min of third-person contraption flight.

Note: `main` refactored `CameraAgent` and no longer has `limitRotateCenter`, but `Zone`'s throwing constructor is still there — the equivalent camera-limit code on `main` may want the same guard.

Relates to #221, #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)